### PR TITLE
add small transaction visualization

### DIFF
--- a/lib/shared/dataClasses/selectable.dart
+++ b/lib/shared/dataClasses/selectable.dart
@@ -11,8 +11,12 @@ abstract class Selectable {
     required this.color,
   });
 
-  Icon getSelectableIconWidget() {
-    return Icon(icon, color: color);
+  Icon getSelectableIconWidget({double size = 24}) {
+    return Icon(
+      icon,
+      color: color,
+      size: size,
+    );
   }
 
   Widget getSelectableIconWithText() {

--- a/lib/shared/widgets/items/transaction_item.dart
+++ b/lib/shared/widgets/items/transaction_item.dart
@@ -2,6 +2,7 @@ import 'package:budgetiser/screens/transactions/transaction_form.dart';
 import 'package:budgetiser/shared/dataClasses/single_transaction.dart';
 import 'package:budgetiser/shared/utils/date_utils.dart';
 import 'package:budgetiser/shared/widgets/smallStuff/balance_text.dart';
+import 'package:budgetiser/shared/widgets/smallStuff/visualize_transaction_small.dart';
 import 'package:flutter/material.dart';
 
 /// Displays a transaction as widget
@@ -32,7 +33,6 @@ class TransactionItem extends StatelessWidget {
           children: [
             // top row
             Row(
-              //TODO: use common widget with transaction for vor visualisation of transaction (with arrows)
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Flexible(
@@ -43,39 +43,7 @@ class TransactionItem extends StatelessWidget {
                     ),
                   ),
                 ),
-                if (transactionData.account2 == null)
-                  Row(
-                    children: [
-                      Icon(
-                        transactionData.category.icon,
-                        color: transactionData.category.color,
-                      ),
-                      const Text(' in '),
-                      Icon(
-                        transactionData.account.icon,
-                        color: transactionData.account.color,
-                      ),
-                    ],
-                  ),
-                if (transactionData.account2 != null)
-                  Row(
-                    children: [
-                      Icon(
-                        transactionData.category.icon,
-                        color: transactionData.category.color,
-                      ),
-                      const Text(' from '),
-                      Icon(
-                        transactionData.account.icon,
-                        color: transactionData.account.color,
-                      ),
-                      const Text(' to '),
-                      Icon(
-                        transactionData.account2!.icon,
-                        color: transactionData.account2!.color,
-                      ),
-                    ],
-                  ),
+                TransactionVisualization(transaction: transactionData),
               ],
             ),
             const SizedBox(height: 8),

--- a/lib/shared/widgets/smallStuff/arrow_icon.dart
+++ b/lib/shared/widgets/smallStuff/arrow_icon.dart
@@ -1,0 +1,32 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+/// white arrow icon
+///
+/// if [flipped] is set the arrow points to the left
+class ArrowIcon extends StatelessWidget {
+  const ArrowIcon({
+    super.key,
+    this.flipped = false,
+    this.size = 60,
+  });
+
+  final bool flipped;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    if (flipped) {
+      return Transform.rotate(
+        angle: pi, // rotate by pi to flip the arrow
+        child: Icon(
+          Icons.arrow_right_alt,
+          size: size,
+        ),
+      );
+    } else {
+      return Icon(Icons.arrow_right_alt, size: size);
+    }
+  }
+}

--- a/lib/shared/widgets/smallStuff/visualize_transaction.dart
+++ b/lib/shared/widgets/smallStuff/visualize_transaction.dart
@@ -49,9 +49,9 @@ class _VisualizeTransactionState extends State<VisualizeTransaction> {
                   clickableAccountIcon(widget.account2!),
                 ]
               : [
-                  clickableAccountIcon(widget.account1!),
-                  ArrowIcon(flipped: !widget.wasNegative),
                   widget.category!.getSelectableIconWidget(size: 40),
+                  ArrowIcon(flipped: widget.wasNegative),
+                  clickableAccountIcon(widget.account1!),
                 ],
         ),
         if (widget.value != null &&

--- a/lib/shared/widgets/smallStuff/visualize_transaction.dart
+++ b/lib/shared/widgets/smallStuff/visualize_transaction.dart
@@ -1,8 +1,7 @@
-import 'dart:math';
-
 import 'package:budgetiser/screens/account/account_form.dart';
 import 'package:budgetiser/shared/dataClasses/account.dart';
 import 'package:budgetiser/shared/dataClasses/transaction_category.dart';
+import 'package:budgetiser/shared/widgets/smallStuff/arrow_icon.dart';
 import 'package:budgetiser/shared/widgets/smallStuff/balance_text.dart';
 import 'package:flutter/material.dart';
 
@@ -40,23 +39,19 @@ class _VisualizeTransactionState extends State<VisualizeTransaction> {
           children: (widget.account2 != null)
               ? [
                   clickableAccountIcon(widget.account1!),
-                  _arrow(flipped: false),
+                  const ArrowIcon(),
                   Icon(
                     widget.category!.icon,
                     color: widget.category!.color,
                     size: 40,
                   ),
-                  _arrow(flipped: false),
+                  const ArrowIcon(),
                   clickableAccountIcon(widget.account2!),
                 ]
               : [
                   clickableAccountIcon(widget.account1!),
-                  _arrow(flipped: !widget.wasNegative),
-                  Icon(
-                    widget.category!.icon,
-                    color: widget.category!.color,
-                    size: 40,
-                  ),
+                  ArrowIcon(flipped: !widget.wasNegative),
+                  widget.category!.getSelectableIconWidget(size: 40),
                 ],
         ),
         if (widget.value != null &&
@@ -89,19 +84,5 @@ class _VisualizeTransactionState extends State<VisualizeTransaction> {
         size: 40,
       ),
     );
-  }
-
-  Widget _arrow({required bool flipped}) {
-    if (flipped) {
-      return Transform.rotate(
-        angle: pi, // rotate by pi to flip the arrow
-        child: const Icon(
-          Icons.arrow_right_alt,
-          size: 60,
-        ),
-      );
-    } else {
-      return const Icon(Icons.arrow_right_alt, size: 60);
-    }
   }
 }

--- a/lib/shared/widgets/smallStuff/visualize_transaction_small.dart
+++ b/lib/shared/widgets/smallStuff/visualize_transaction_small.dart
@@ -17,7 +17,7 @@ class TransactionVisualization extends StatelessWidget {
       return Row(
         children: [
           transaction.category.getSelectableIconWidget(),
-          const ArrowIcon(size: 32),
+          ArrowIcon(size: 32, flipped: transaction.value < 0),
           transaction.account.getSelectableIconWidget(),
         ],
       );

--- a/lib/shared/widgets/smallStuff/visualize_transaction_small.dart
+++ b/lib/shared/widgets/smallStuff/visualize_transaction_small.dart
@@ -1,0 +1,36 @@
+import 'package:budgetiser/shared/dataClasses/single_transaction.dart';
+import 'package:budgetiser/shared/widgets/smallStuff/arrow_icon.dart';
+import 'package:flutter/material.dart';
+
+/// small transaction visualization with arrow and icons for category and account/s
+class TransactionVisualization extends StatelessWidget {
+  const TransactionVisualization({
+    super.key,
+    required this.transaction,
+  });
+
+  final SingleTransaction transaction;
+
+  @override
+  Widget build(BuildContext context) {
+    if (transaction.account2 == null) {
+      return Row(
+        children: [
+          transaction.category.getSelectableIconWidget(),
+          const ArrowIcon(size: 32),
+          transaction.account.getSelectableIconWidget(),
+        ],
+      );
+    } else {
+      return Row(
+        children: [
+          transaction.account.getSelectableIconWidget(),
+          const ArrowIcon(size: 32),
+          transaction.category.getSelectableIconWidget(),
+          const ArrowIcon(size: 32),
+          transaction.account2!.getSelectableIconWidget(),
+        ],
+      );
+    }
+  }
+}


### PR DESCRIPTION
![grafik](https://github.com/budgetiser/budgetiser/assets/75438446/e3ad6b0e-7c9d-4804-8ccb-84a431c5dc6e)

not same widget as deadspace icons can be clicked and have a different size