### PR TITLE
Account-archive

### DIFF
--- a/lib/accounts/screens/account_form.dart
+++ b/lib/accounts/screens/account_form.dart
@@ -28,6 +28,7 @@ class _AccountFormState extends State<AccountForm> {
   final _formKey = GlobalKey<FormState>();
   Color _color = randomColor();
   IconData _icon = Icons.abc;
+  bool _isArchived = false;
 
   @override
   void initState() {
@@ -39,6 +40,7 @@ class _AccountFormState extends State<AccountForm> {
       descriptionController.text = widget.initialAccount!.description ?? '';
       _color = widget.initialAccount!.color;
       _icon = widget.initialAccount!.icon;
+      _isArchived = widget.initialAccount!.archived;
     }
   }
 
@@ -127,15 +129,15 @@ class _AccountFormState extends State<AccountForm> {
                       return null;
                     },
                   ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 20),
-                    child: TextFormField(
-                      controller: descriptionController,
-                      keyboardType: TextInputType.multiline,
-                      decoration: const InputDecoration(
-                        labelText: 'Description',
-                        border: OutlineInputBorder(),
-                      ),
+                  const SizedBox(
+                    height: 16,
+                  ),
+                  TextFormField(
+                    controller: descriptionController,
+                    keyboardType: TextInputType.multiline,
+                    decoration: const InputDecoration(
+                      labelText: 'Description',
+                      border: OutlineInputBorder(),
                     ),
                   ),
                   // account action buttons
@@ -143,6 +145,14 @@ class _AccountFormState extends State<AccountForm> {
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
+                        const SizedBox(
+                          height: 16,
+                        ),
+                        SwitchListTile(
+                          title: const Text('Archive'),
+                          value: _isArchived,
+                          onChanged: archiveToggle,
+                        ),
                         const SizedBox(
                           height: 16,
                         ),
@@ -203,6 +213,7 @@ class _AccountFormState extends State<AccountForm> {
                 balance: double.parse(balanceController.text),
                 description: parseNullableString(descriptionController.text),
                 id: 0,
+                archived: _isArchived,
               );
               if (widget.initialAccount != null) {
                 a.id = widget.initialAccount!.id;
@@ -220,6 +231,43 @@ class _AccountFormState extends State<AccountForm> {
         ),
       ]),
     );
+  }
+
+  void archiveToggle(value) {
+    if (value == true) {
+      showDialog(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('Archive'),
+            content: const Text(
+              'Archiving an account removes the account from selections in the Transactions forms.\nThis does not affect any statistics.',
+            ),
+            actions: [
+              TextButton(
+                child: const Text('Cancel'),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+              TextButton(
+                child: const Text('Ok'),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  setState(() {
+                    _isArchived = true;
+                  });
+                },
+              ),
+            ],
+          );
+        },
+      );
+    } else {
+      setState(() {
+        _isArchived = false;
+      });
+    }
   }
 
   Future showBalanceDialog(BuildContext context) {

--- a/lib/accounts/screens/account_screen.dart
+++ b/lib/accounts/screens/account_screen.dart
@@ -114,18 +114,53 @@ class _AccountScreenState extends State<AccountScreen> {
               return const Text('Oops!');
             }
             snapshot.data!.sort(sortFunction);
-            return ListView.builder(
-              itemCount: snapshot.data!.length,
-              padding: const EdgeInsets.only(bottom: 80),
-              itemBuilder: (BuildContext context, int index) {
-                return AccountItem(
-                  accountData: snapshot.data![index],
-                );
-              },
+            var accountList =
+                snapshot.data!.where((element) => !element.archived).toList();
+            var archivedAccountList =
+                snapshot.data!.where((element) => element.archived).toList();
+            return SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ListView.builder(
+                    physics: const NeverScrollableScrollPhysics(),
+                    shrinkWrap: true,
+                    itemCount: accountList.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      return AccountItem(
+                        accountData: accountList[index],
+                      );
+                    },
+                  ),
+                  ...archivedAccounts(archivedAccountList),
+                ],
+              ),
             );
           },
         );
       },
     );
+  }
+
+  List<Widget> archivedAccounts(List<Account> archivedAccountList) {
+    if (archivedAccountList.isEmpty) return [];
+    return [
+      const Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Text('Archived'),
+      ),
+      ListView.builder(
+        physics: const NeverScrollableScrollPhysics(),
+        shrinkWrap: true,
+        itemCount: archivedAccountList.length,
+        padding: const EdgeInsets.only(bottom: 80),
+        itemBuilder: (BuildContext context, int index) {
+          return AccountItem(
+            accountData: archivedAccountList[index],
+          );
+        },
+      )
+    ];
   }
 }

--- a/lib/accounts/widgets/account_single_picker.dart
+++ b/lib/accounts/widgets/account_single_picker.dart
@@ -10,10 +10,12 @@ class AccountSinglePicker extends StatefulWidget {
     super.key,
     required this.onAccountPickedCallback,
     this.blacklistedValues,
+    this.ignoreArchived = false,
   });
 
   final Function(Account selected) onAccountPickedCallback;
   final List<Account>? blacklistedValues;
+  final bool ignoreArchived;
 
   @override
   State<AccountSinglePicker> createState() => _AccountSinglePickerState();
@@ -23,8 +25,9 @@ class _AccountSinglePickerState extends State<AccountSinglePicker> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<List<Account>>(
-      future:
-          Provider.of<AccountModel>(context, listen: false).getAllAccounts(),
+      future: Provider.of<AccountModel>(context, listen: false).getAllAccounts(
+        ignoreArchived: widget.ignoreArchived,
+      ),
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const Center(

--- a/lib/accounts/widgets/account_single_picker_nullable.dart
+++ b/lib/accounts/widgets/account_single_picker_nullable.dart
@@ -9,10 +9,12 @@ class AccountSinglePickerNullable extends StatefulWidget {
     super.key,
     required this.onAccountPickedCallback,
     this.blacklistedValues,
+    this.ignoreArchived = false,
   });
 
   final Function(Account? selected) onAccountPickedCallback;
   final List<Account>? blacklistedValues;
+  final bool ignoreArchived;
 
   @override
   State<AccountSinglePickerNullable> createState() =>
@@ -24,8 +26,9 @@ class _AccountSinglePickerNullableState
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<List<Account>>(
-      future:
-          Provider.of<AccountModel>(context, listen: false).getAllAccounts(),
+      future: Provider.of<AccountModel>(context, listen: false).getAllAccounts(
+        ignoreArchived: widget.ignoreArchived,
+      ),
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const Center(

--- a/lib/core/database/provider/account_provider.dart
+++ b/lib/core/database/provider/account_provider.dart
@@ -8,24 +8,18 @@ import 'package:sqflite/sqflite.dart';
 
 class AccountModel extends ChangeNotifier {
   final recentlyUsedAccount = RecentlyUsed<Account>();
-  DateTime lastTimeFetchedAllAccounts = DateTime(0);
-  List<Account> cachedAllAccounts = [];
 
-  Future<List<Account>> getAllAccounts() async {
-    debugPrint(
-        'since last cache ${DateTime.now().difference(lastTimeFetchedAllAccounts).inMilliseconds}');
-    if (DateTime.now().difference(lastTimeFetchedAllAccounts) <
-        const Duration(milliseconds: 200)) {
-      return cachedAllAccounts;
-    }
+  Future<List<Account>> getAllAccounts({bool ignoreArchived = false}) async {
     final db = await DatabaseHelper.instance.database;
-    final List<Map<String, dynamic>> maps = await db.query('account');
+    final List<Map<String, dynamic>> maps = await db.query(
+      'account',
+      where: ignoreArchived ? 'archived != 0' : 'true',
+    );
 
     List<Account> accounts = List.generate(maps.length, (i) {
       return Account.fromDBmap(maps[i]);
     });
-    lastTimeFetchedAllAccounts = DateTime.now();
-    cachedAllAccounts = accounts;
+    debugPrint('Fetched ${accounts.length} accounts');
     return accounts;
   }
 

--- a/lib/transactions/screens/transaction_form.dart
+++ b/lib/transactions/screens/transaction_form.dart
@@ -329,6 +329,7 @@ class _TransactionFormState extends State<TransactionForm> {
               context: context,
               builder: (BuildContext context) {
                 return AccountSinglePicker(
+                  ignoreArchived: true,
                   onAccountPickedCallback: setAccount,
                 );
               },
@@ -346,6 +347,7 @@ class _TransactionFormState extends State<TransactionForm> {
               context: context,
               builder: (BuildContext context) {
                 return AccountSinglePickerNullable(
+                  ignoreArchived: true,
                   onAccountPickedCallback: setAccount2,
                   blacklistedValues:
                       selectedAccount != null ? [selectedAccount!] : null,


### PR DESCRIPTION
not done (from #143 ):
- multi selector with greyed out but still visible & usable

done:
- toggle in account form for archiving
- remove archived accounts from single selection in transaction form
- show archived accounts separate in account screen

| ![Screenshot_1720789810](https://github.com/user-attachments/assets/771f2709-288c-493c-af98-a3802bf92c41) | ![Screenshot_1720789817](https://github.com/user-attachments/assets/0d7f9e07-0676-4231-adfb-82701afe64e7) | ![Screenshot_1720789827](https://github.com/user-attachments/assets/fb1de16a-75f0-449e-b25b-e6a5279ed595) |
|-|-|-|

