### PR TITLE
redesigned transaction items and add grouped list to expansion tile

### DIFF
--- a/lib/transactions/widgets/transaction_expansion_tile.dart
+++ b/lib/transactions/widgets/transaction_expansion_tile.dart
@@ -4,6 +4,8 @@ import 'package:budgetiser/core/database/models/transaction.dart';
 import 'package:budgetiser/core/database/provider/transaction_provider.dart';
 import 'package:budgetiser/transactions/widgets/transaction_item.dart';
 import 'package:flutter/material.dart';
+import 'package:grouped_list/grouped_list.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class TransactionExpansionTile extends StatelessWidget {
@@ -49,16 +51,24 @@ class TransactionExpansionTile extends StatelessWidget {
               if (snapshot.data!.isEmpty) {
                 return Container();
               }
-              return ListView.builder(
-                prototypeItem: TransactionItem(
-                  transactionData: snapshot.data!.first,
-                ),
+              DateFormat dateFormat = DateFormat('yyyy-MM-dd');
+              return GroupedListView<SingleTransaction, String>(
                 shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: snapshot.data!.length,
-                itemBuilder: (context, index) {
+                elements: snapshot.data!,
+                groupBy: (element) => dateFormat.format(element.date),
+                groupComparator: (value1, value2) => value2.compareTo(value1),
+                itemComparator: (item1, item2) =>
+                    item1.date.compareTo(item2.date),
+                groupSeparatorBuilder: (String value) => Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    value,
+                    style: Theme.of(context).textTheme.labelMedium,
+                  ),
+                ),
+                itemBuilder: (c, element) {
                   return TransactionItem(
-                    transactionData: snapshot.data![index],
+                    transactionData: element,
                   );
                 },
               );

--- a/lib/transactions/widgets/transaction_item.dart
+++ b/lib/transactions/widgets/transaction_item.dart
@@ -1,6 +1,7 @@
 import 'package:budgetiser/core/database/models/transaction.dart';
 import 'package:budgetiser/shared/utils/date_utils.dart';
 import 'package:budgetiser/shared/widgets/balance_text.dart';
+import 'package:budgetiser/shared/widgets/selectable/selectable_icon.dart';
 import 'package:budgetiser/transactions/screens/transaction_form.dart';
 import 'package:budgetiser/transactions/widgets/visualize_transaction_small.dart';
 import 'package:flutter/material.dart';
@@ -29,50 +30,63 @@ class TransactionItem extends StatelessWidget {
       },
       child: Container(
         margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-        child: Column(
+        child: Row(
           children: [
-            // top row
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Flexible(
-                  child: Text(
-                    transactionData.title,
-                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                TransactionVisualization(transaction: transactionData),
-              ],
+            SelectableIcon(
+              transactionData.category,
+              size: 40,
             ),
-            const SizedBox(height: 8),
-            // second/bottom row
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  dateAsDDMMYYYY(transactionData.date),
-                ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      transactionData.description ?? '',
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                      textWidthBasis: TextWidthBasis.parent,
-                    ),
+            const SizedBox(
+              width: 16,
+            ),
+            Expanded(
+              child: Column(
+                children: [
+                  // top row
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          transactionData.title,
+                          style:
+                              Theme.of(context).textTheme.bodyLarge!.copyWith(
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      TransactionAccountVisualizationSmall(
+                        transaction: transactionData,
+                      ),
+                    ],
                   ),
-                ),
-                BalanceText(
-                  transactionData.value,
-                  isColored: transactionData.account2 == null &&
-                      transactionData.value != 0,
-                  hasPrefix: transactionData.account2 == null,
-                ),
-              ],
+                  const SizedBox(height: 4),
+                  // second/bottom row
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.only(right: 16),
+                          child: Text(
+                            transactionData.description ?? '',
+                            overflow: TextOverflow.ellipsis,
+                            maxLines: 1,
+                            textWidthBasis: TextWidthBasis.parent,
+                          ),
+                        ),
+                      ),
+                      BalanceText(
+                        transactionData.value,
+                        isColored: transactionData.account2 == null &&
+                            transactionData.value != 0,
+                        hasPrefix: transactionData.account2 == null,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/transactions/widgets/transaction_item.dart
+++ b/lib/transactions/widgets/transaction_item.dart
@@ -1,5 +1,4 @@
 import 'package:budgetiser/core/database/models/transaction.dart';
-import 'package:budgetiser/shared/utils/date_utils.dart';
 import 'package:budgetiser/shared/widgets/balance_text.dart';
 import 'package:budgetiser/shared/widgets/selectable/selectable_icon.dart';
 import 'package:budgetiser/transactions/screens/transaction_form.dart';

--- a/lib/transactions/widgets/visualize_transaction_small.dart
+++ b/lib/transactions/widgets/visualize_transaction_small.dart
@@ -3,9 +3,9 @@ import 'package:budgetiser/shared/widgets/arrow_icon.dart';
 import 'package:budgetiser/shared/widgets/selectable/selectable_icon.dart';
 import 'package:flutter/material.dart';
 
-class TransactionVisualization extends StatelessWidget {
-  /// small transaction visualization with arrow and icons for category and account/s
-  const TransactionVisualization({
+class TransactionAccountVisualizationSmall extends StatelessWidget {
+  /// small transaction visualization with arrow and icons for account/s
+  const TransactionAccountVisualizationSmall({
     super.key,
     required this.transaction,
   });
@@ -15,20 +15,12 @@ class TransactionVisualization extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (transaction.account2 == null) {
-      return Row(
-        children: [
-          SelectableIcon(transaction.category),
-          ArrowIcon(size: 32, flipped: transaction.value < 0),
-          SelectableIcon(transaction.account),
-        ],
-      );
+      return SelectableIcon(transaction.account);
     } else {
       return Row(
         children: [
           SelectableIcon(transaction.account),
-          const ArrowIcon(size: 32),
-          SelectableIcon(transaction.category),
-          const ArrowIcon(size: 32),
+          const ArrowIcon(size: 20),
           SelectableIcon(transaction.account2!),
         ],
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -266,6 +266,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  grouped_list:
+    dependency: "direct main"
+    description:
+      name: grouped_list
+      sha256: c52551bc17699e304634d4653b824a1aa7c6b1d3a2c1a0da1a80839f867353fb
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   flutter_file_dialog: ^3.0.2
   badges: ^3.1.2
   fuzzywuzzy: ^1.1.6
+  grouped_list: ^6.0.0
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
## Changes
- new transaction items
- months contain now a list of transactions grouped by day

## Screenshots

![Screenshot_1724963340](https://github.com/user-attachments/assets/1ac7c4d3-9c49-4ab1-8184-299a584373ce)
